### PR TITLE
複数プロンプトの際、ignore-idx のための対応テンプレート探しを key-value に変更

### DIFF
--- a/train.py
+++ b/train.py
@@ -151,19 +151,22 @@ def main() -> None:
         )
     else:
         try:
-            templates = [TEMPLATES[template] for template in sft_training_args.templates]
+            templates = {template: TEMPLATES[template] for template in sft_training_args.templates}
         except KeyError as e:
             raise ValueError(f"Template '{e}' is not found") from e
 
-        response_ids = [tokenizer.encode(template.response_prefix, add_special_tokens=False)[1:] for template in templates]
-        instruction_ids = [
-            (
+        response_ids = {
+            template_name: tokenizer.encode(template.response_prefix, add_special_tokens=False)[1:]
+            for template_name, template in templates.items()
+        }
+        instruction_ids = {
+            template_name: (
                 tokenizer.encode(template.instruction_prefix, add_special_tokens=False)[1:]
                 if template.instruction_prefix is not None
                 else None
             )
-            for template in templates
-        ]
+            for template_name, template in templates.items()
+        }
 
         collator = DataCollatorForCompletionOnlyLMWithMultiTemplate(
             instruction_templates=instruction_ids,


### PR DESCRIPTION
以前まで簡単に単語 id で探索を実施していたが、その場合、意図しない ignore idx が発生する可能性があるため、
key-value で対応するように変更した。