### PR TITLE
Fix for none template

### DIFF
--- a/data_collator.py
+++ b/data_collator.py
@@ -76,6 +76,9 @@ class DataCollatorForCompletionOnlyLMWithMultiTemplate(DataCollatorForLanguageMo
                 response_token_ids_start_idx: Optional[int] = None
 
                 prompt_type = examples[i]["prompt_type"]
+                if prompt_type == "none":
+                    # if prompt_type is none, train the model as clm.
+                    continue
                 target_template = self.responses_token_ids.get(prompt_type)
                 assert target_template is not None, f"Template '{prompt_type}' is not found"
 
@@ -105,6 +108,9 @@ class DataCollatorForCompletionOnlyLMWithMultiTemplate(DataCollatorForLanguageMo
                 human_token_ids_idxs: List[int] = []  # start idxs
 
                 prompt_type = examples[i]["prompt_type"]
+                if prompt_type == "none":
+                    # if prompt_type is none, train the model as clm.
+                    continue
                 target_template = self.responses_token_ids.get(prompt_type)
                 assert target_template is not None, f"Template '{prompt_type}' is not found"
 

--- a/templates.py
+++ b/templates.py
@@ -11,5 +11,5 @@ class PromptTemplate:
 TEMPLATES = {
     "alpaca": PromptTemplate(instruction_prefix="\n\n### 指示:\n", response_prefix="\n\n### 応答:\n"),
     "chat": PromptTemplate(instruction_prefix="USER:", response_prefix="\nASSISTANT:"),
-    "none": PromptTemplate(response_prefix="\n"),  # 真のプロンプトなし（空文字）は SFT の学習上、難しいというか入出力を切りたいので、改行だけ入れる
+    "none": PromptTemplate(response_prefix="fake token"),  # none の場合、Instruction Tuning として学習するのではなく、通常の CLM として学習する。そのため、response prefix も本来は不要だが、データ形式の都合上、ダミーのトークンを入れている。
 }


### PR DESCRIPTION
template が `none` の場合、通常の CLM として学習するように変更を行う