### PR TITLE
Update trl for unused_columns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -244,7 +244,7 @@ transformers==4.36.2
     #   trl
 triton==2.1.0
     # via torch
-trl==0.7.4
+trl==0.7.11
     # via -r requirements.in
 typing-extensions==4.9.0
     # via


### PR DESCRIPTION
trl が no_remove_unused_columns に対応しているのが v0.7.8 からなので、それ以上のバージョンとして v0.7.11 を指定